### PR TITLE
support enum in fitsable

### DIFF
--- a/autoconf/fitsable.py
+++ b/autoconf/fitsable.py
@@ -99,7 +99,10 @@ def hdu_list_for_output_from(
 
     if header_dict is not None:
         for key, value in header_dict.items():
-            header.append((key, value, [""]))
+            try:
+                header.append((key, value, [""]))
+            except ValueError:
+                header.append((key.value, value, [""])) # If enum is used for headeer_dict
     
     for i, values in enumerate(values_list):
     

--- a/autoconf/fitsable.py
+++ b/autoconf/fitsable.py
@@ -100,10 +100,9 @@ def hdu_list_for_output_from(
 
     if header_dict is not None:
         for key, value in header_dict.items():
-            try:
-                header.append((key, value, [""]))
-            except ValueError:
-                header.append((key.value, value, [""])) # If enum is used for headeer_dict
+            # Convert enum to its string value if needed
+            key_str = key.value if isinstance(key, Enum) else key
+            header.append((key_str, value, [""]))
     
     for i, values in enumerate(values_list):
     

--- a/autoconf/fitsable.py
+++ b/autoconf/fitsable.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:


### PR DESCRIPTION
This pull request includes a small change to the `autoconf/fitsable.py` file. The change adds error handling when appending to the `header` list in the `hdu_list_for_output_from` function to account for the `header_dict` using `enum`s instead of just a dictionary.

Error handling improvement:

* [`autoconf/fitsable.py`](diffhunk://#diff-496db90860ff0a198218b0bf4212ee50feac5460825c3931071db2fff5ed3004R102-R105): Added a `try-except` block to handle `ValueError` exceptions when appending to the `header` list, ensuring compatibility with enum types used in `header_dict`.