### PR TITLE
fix: guard YAMLConfig.keys() against non-dict YAML content

### DIFF
--- a/autoconf/directory_config.py
+++ b/autoconf/directory_config.py
@@ -80,6 +80,8 @@ class YAMLConfig(AbstractConfig):
         return value
 
     def keys(self):
+        if not isinstance(self._dict, dict):
+            return iter(())
         return self._dict.keys()
 
 


### PR DESCRIPTION
## Summary
YAML files with list content at the top level (e.g. `no_run.yaml`) caused `AttributeError: 'list' object has no attribute 'keys'` when the config system iterated their keys during startup. This broke all workspace script imports. Added a type guard in `YAMLConfig.keys()` to return empty keys for non-dict YAML files.

## API Changes
None — internal changes only.

## Test Plan
- [x] All 71 PyAutoConf unit tests pass
- [x] `import autofit as af; import autolens as al` succeeds in autolens_workspace
- [ ] Workspace smoke tests

<details>
<summary>Full API Changes (for automation & release notes)</summary>

No public API changes. Internal defensive fix only.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)