### PR TITLE
build: raise numpy, jax, jaxlib version caps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ keywords = ["cli"]
 dependencies = [
     "pathlib",
     "jaxnnls==1.0.1",
-    "jax>=0.4.13,<0.5.0",
-    "jaxlib>=0.4.13,<0.5.0",
+    "jax>=0.4.35,<0.10.0",
+    "jaxlib>=0.4.35,<0.10.0",
     "typing-inspect>=0.4.0",
     "PyYAML>=6.0.1",
-    "numpy>=1.24.0,<=2.0.1"
+    "numpy>=1.24.0,<3.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
Raise version caps on core dependencies as part of a cross-ecosystem dependency sweep. numpy cap raised from <=2.0.1 to <3.0.0, jax/jaxlib from <0.5.0 to <0.10.0 with floor bumped to >=0.4.35 (ensures ARM64 macOS wheels are available).

Tracked in PyAutoLabs/PyAutoConf#87.

## API Changes
None — internal changes only.

## Test Plan
- [x] PyAutoConf unit tests pass (71/71)
- [x] Full stack tests pass (3,070 across 5 repos)
- [x] CI green on all 5 repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)