### PR TITLE
build: add Python 3.13 to CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.12', '3.13']
     steps:
     - name: Checkout PyAutoConf
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ jobs:
   unittest:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.12', '3.13']
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
   "Natural Language :: English",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.12"
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13"
 ]
 keywords = ["cli"]
 dependencies = [


### PR DESCRIPTION
## Summary
Add Python 3.13 to the GitHub Actions CI matrix with `fail-fast: false`, and add the 3.13 classifier to pyproject.toml. Both 3.12 and 3.13 jobs pass.

## API Changes
None — internal changes only.

## Test Plan
- [x] CI passes on Python 3.12
- [x] CI passes on Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)