### PR TITLE
fix: add Python version check and update homepage URL

### DIFF
--- a/autoconf/__init__.py
+++ b/autoconf/__init__.py
@@ -1,3 +1,11 @@
+import sys
+
+if sys.version_info < (3, 12):
+    raise RuntimeError(
+        f"PyAutoConf requires Python 3.12 or later. "
+        f"You are running Python {sys.version_info.major}.{sys.version_info.minor}."
+    )
+
 from . import jax_wrapper
 from . import exc
 from .tools.decorators import cached_property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/rhayes777/PyAutoConf"
+Homepage = "https://github.com/PyAutoLabs/PyAutoConf"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Summary
- Add runtime check for Python >= 3.12 at import time — users on older Python now get a clear `RuntimeError` instead of cryptic import failures
- Update homepage URL from `rhayes777/PyAutoConf` to `PyAutoLabs/PyAutoConf`

## Test plan
- [ ] `python -c "import autoconf"` works on Python 3.12+
- [ ] Verify error message on Python < 3.12 if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)