### PR TITLE
feat: add lazy JAX pytree registration helpers to autoconf

### DIFF
--- a/autoconf/jax_wrapper.py
+++ b/autoconf/jax_wrapper.py
@@ -47,8 +47,40 @@ if not jax_enable_x64:
         """"
         JAX 64-bit precision has been automatically enabled for you (JAX_ENABLE_X64=True),
         as double precision is required for most scientific computing applications.
-        
-        To enable 64 precision as default in JAX, set the environment variable 
+
+        To enable 64 precision as default in JAX, set the environment variable
         JAX_ENABLE_X64=true before running your script.
         """
     )
+
+
+def register_pytree_node_class(cls):
+    """Opt-in JAX pytree class registration that defers the JAX import.
+
+    The previous eager registration in ``autofit.mapper.prior_model.prior_model``
+    forced ``jax.tree_util`` to load whenever ``import autofit`` ran. To keep
+    JAX an optional dependency, library code now exposes ``tree_flatten`` /
+    ``tree_unflatten`` methods but does NOT register the class itself; callers
+    that want JAX integration call this helper explicitly (typically via
+    ``autofit.jax.enable_pytrees()``).
+
+    No-ops if JAX is not installed.
+    """
+    try:
+        from jax.tree_util import register_pytree_node_class as _r
+    except ImportError:
+        return cls
+    return _r(cls)
+
+
+def register_pytree_node(nodetype, flatten_func, unflatten_func):
+    """Opt-in JAX pytree registration for an externally-defined class.
+
+    Lazy counterpart to :func:`register_pytree_node_class` for the case where
+    the class cannot be decorated directly. No-ops if JAX is not installed.
+    """
+    try:
+        from jax.tree_util import register_pytree_node as _r
+    except ImportError:
+        return None
+    return _r(nodetype, flatten_func, unflatten_func)


### PR DESCRIPTION
## Summary
Add two lazy helpers to `autoconf.jax_wrapper` — `register_pytree_node_class(cls)` and `register_pytree_node(nodetype, flatten_func, unflatten_func)` — that defer the `jax.tree_util` import to call time and no-op if JAX is not installed.

These unblock `autofit.jax.enable_pytrees()` (PyAutoFit PR) which needs to register PyAutoFit model classes as JAX pytree nodes without forcing a JAX import on every `import autofit`.

## API Changes
Additive only. Two new public helpers on `autoconf.jax_wrapper`:
- `register_pytree_node_class(cls)` — lazy equivalent of `jax.tree_util.register_pytree_node_class`
- `register_pytree_node(nodetype, flatten_func, unflatten_func)` — lazy equivalent of `jax.tree_util.register_pytree_node`

Both no-op if JAX is missing. See full details below.

## Test Plan
- [x] `pytest test_autoconf/` passes (71 tests)
- [x] Callers in PyAutoFit (`autofit.jax.enable_pytrees`) import and use both helpers successfully

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autoconf.jax_wrapper.register_pytree_node_class(cls)` — registers `cls` with `jax.tree_util` when JAX is present; returns `cls` unchanged otherwise.
- `autoconf.jax_wrapper.register_pytree_node(nodetype, flatten_func, unflatten_func)` — registers a non-decoratable class; returns `None` when JAX is missing.

### Removed / Renamed / Changed Signature / Changed Behaviour
None.

### Migration
None. Existing callers of `autoconf.jax_wrapper` are unaffected.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)