### PR TITLE
feat(workspace): add version-mismatch check helper

### DIFF
--- a/autoconf/__init__.py
+++ b/autoconf/__init__.py
@@ -19,6 +19,7 @@ from .json_prior.config import JSONPriorConfig
 from .setup_colab import for_autolens
 from .setup_notebook import setup_notebook
 from .test_mode import test_mode_level, is_test_mode, skip_fit_output, skip_visualization, skip_checks
+from .workspace import check_version, WorkspaceVersionMismatchError
 
 
 __version__ = "2026.4.13.6"

--- a/autoconf/workspace.py
+++ b/autoconf/workspace.py
@@ -1,0 +1,52 @@
+import os
+import warnings
+from pathlib import Path
+
+from autoconf import exc
+
+
+class WorkspaceVersionMismatchError(exc.ConfigException):
+    pass
+
+
+def check_version(library_version, workspace_root=None):
+    """
+    Verify that the workspace at ``workspace_root`` matches ``library_version``.
+
+    Reads ``version.txt`` from ``workspace_root`` (defaults to the current
+    working directory, which is where users run workspace scripts from).
+    Raises ``WorkspaceVersionMismatchError`` if the file's version differs
+    from ``library_version``. If ``version.txt`` does not exist (e.g. an
+    older workspace clone or one cloned from ``main`` outside a release tag)
+    a warning is emitted and the check is skipped.
+
+    Set ``PYAUTO_SKIP_WORKSPACE_VERSION_CHECK=1`` to disable the check
+    entirely — intended for developers running source checkouts where
+    workspace and library versions intentionally diverge.
+    """
+    if os.environ.get("PYAUTO_SKIP_WORKSPACE_VERSION_CHECK") == "1":
+        return
+
+    root = Path(workspace_root) if workspace_root else Path.cwd()
+    version_file = root / "version.txt"
+
+    if not version_file.exists():
+        warnings.warn(
+            f"No version.txt found at {version_file}. Cannot verify that the "
+            f"workspace matches the installed library version ({library_version}). "
+            f"If you cloned the workspace from main rather than a release tag, "
+            f"set PYAUTO_SKIP_WORKSPACE_VERSION_CHECK=1 to silence this warning."
+        )
+        return
+
+    workspace_version = version_file.read_text().strip()
+
+    if workspace_version != library_version:
+        raise WorkspaceVersionMismatchError(
+            f"Workspace version ({workspace_version}) at {root} does not match "
+            f"the installed library version ({library_version}). Re-clone the "
+            f"workspace at the matching tag:\n\n"
+            f"    git clone --branch {library_version} <workspace-repo-url>\n\n"
+            f"Or set PYAUTO_SKIP_WORKSPACE_VERSION_CHECK=1 to override (intended "
+            f"for source-checkout development)."
+        )

--- a/test_autoconf/test_workspace.py
+++ b/test_autoconf/test_workspace.py
@@ -1,0 +1,38 @@
+import pytest
+
+from autoconf.workspace import check_version, WorkspaceVersionMismatchError
+
+
+def test_match(tmp_path):
+    (tmp_path / "version.txt").write_text("2026.4.13.6\n")
+    check_version("2026.4.13.6", workspace_root=tmp_path)
+
+
+def test_mismatch_raises(tmp_path):
+    (tmp_path / "version.txt").write_text("2026.4.13.6\n")
+    with pytest.raises(WorkspaceVersionMismatchError) as info:
+        check_version("2025.1.1.1", workspace_root=tmp_path)
+    assert "2026.4.13.6" in str(info.value)
+    assert "2025.1.1.1" in str(info.value)
+
+
+def test_missing_file_warns(tmp_path):
+    with pytest.warns(UserWarning, match="No version.txt"):
+        check_version("2026.4.13.6", workspace_root=tmp_path)
+
+
+def test_env_override_skips_mismatch(tmp_path, monkeypatch):
+    monkeypatch.setenv("PYAUTO_SKIP_WORKSPACE_VERSION_CHECK", "1")
+    (tmp_path / "version.txt").write_text("2025.1.1.1\n")
+    check_version("2026.4.13.6", workspace_root=tmp_path)
+
+
+def test_env_override_skips_missing_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("PYAUTO_SKIP_WORKSPACE_VERSION_CHECK", "1")
+    check_version("2026.4.13.6", workspace_root=tmp_path)
+
+
+def test_default_root_is_cwd(tmp_path, monkeypatch):
+    (tmp_path / "version.txt").write_text("2026.4.13.6\n")
+    monkeypatch.chdir(tmp_path)
+    check_version("2026.4.13.6")


### PR DESCRIPTION
## Summary

Adds `autoconf.workspace.check_version()` so a workspace's `version.txt` can be paired to the installed library version. Companion to PyAutoLabs/autolens_workspace#71 (drop the `release` branch in favour of version-paired workspace tags).

## API Changes

Added one helper and one exception, both exported from the top-level `autoconf` namespace:

- `autoconf.check_version(library_version, workspace_root=None)` — reads `<workspace_root>/version.txt` and raises if it does not match `library_version`. Defaults to the current working directory.
- `autoconf.WorkspaceVersionMismatchError` — subclass of `ConfigException`.

Override the check entirely with `PYAUTO_SKIP_WORKSPACE_VERSION_CHECK=1` (intended for source-checkout development). Missing `version.txt` warns rather than raises.

See full details below.

## Test Plan

- [x] `pytest test_autoconf/test_workspace.py` — 6 new tests cover match, mismatch, missing-file warning, env override, and default cwd resolution.
- [x] Full PyAutoConf suite — 77 tests pass.
- [ ] Once `welcome.py` in each workspace calls this from the workspace root, verify mismatch raises with a clear message.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autoconf.workspace.check_version(library_version, workspace_root=None)` — verifies the workspace at `workspace_root` (or `cwd`) has a `version.txt` matching `library_version`. Raises `WorkspaceVersionMismatchError` on mismatch. Warns if `version.txt` is absent. No-op when `PYAUTO_SKIP_WORKSPACE_VERSION_CHECK=1`.
- `autoconf.workspace.WorkspaceVersionMismatchError` — subclass of `autoconf.exc.ConfigException`.
- Both re-exported from `autoconf.__init__` as `autoconf.check_version` and `autoconf.WorkspaceVersionMismatchError`.

### Removed
None.

### Changed Signature
None.

### Migration
None — purely additive.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)