### PR TITLE
Soften Python version check with general.yaml bypass

### DIFF
--- a/autoconf/__init__.py
+++ b/autoconf/__init__.py
@@ -8,11 +8,38 @@ Text-format I/O surfaces:
 - :mod:`autoconf.csvable`   — CSV  (``output_to_csv`` / ``list_from_csv``)
 """
 import sys
+from pathlib import Path
 
-if sys.version_info < (3, 12):
+
+def _python_version_check_bypassed():
+    """
+    Return True iff the user's workspace config disables the Python version check.
+
+    Reads ``<cwd>/config/general.yaml`` and looks for ``version.python_version_check``.
+    Any failure (missing file, unreadable YAML, missing key, missing yaml module) is
+    treated as "not bypassed" so the default check still fires.
+    """
+    try:
+        import yaml
+
+        config_path = Path.cwd() / "config" / "general.yaml"
+        with config_path.open("r") as f:
+            data = yaml.safe_load(f) or {}
+        return data.get("version", {}).get("python_version_check") is False
+    except Exception:
+        return False
+
+
+if sys.version_info < (3, 12) and not _python_version_check_bypassed():
     raise RuntimeError(
-        f"PyAutoConf requires Python 3.12 or later. "
-        f"You are running Python {sys.version_info.major}.{sys.version_info.minor}."
+        f"Python {sys.version_info.major}.{sys.version_info.minor} detected. "
+        f"PyAutoConf is officially supported on Python 3.12+.\n"
+        f"Python 3.9, 3.10, and 3.11 will technically work but are not tested against.\n"
+        f"\n"
+        f"To bypass this check, add the following to your config/general.yaml:\n"
+        f"\n"
+        f"  version:\n"
+        f"    python_version_check: False\n"
     )
 
 from . import jax_wrapper


### PR DESCRIPTION
## Summary

- Replaces the hard `RuntimeError` for Python < 3.12 with a softer check that can be bypassed via `version.python_version_check: False` in a workspace's `config/general.yaml`.
- Updates the error message to accurately describe reality: Python 3.9/3.10/3.11 technically work but aren't officially tested against; 3.12+ is the supported track.
- Default behaviour on workspaces that haven't opted in is **unchanged** — the check still raises if Python < 3.12, just with a clearer message that names the working-but-unsupported versions and shows the YAML snippet to bypass.

## Why

The PyAutoGPU venv is still on Python 3.10 and was being blocked from importing `autoconf` entirely, even though nothing in the library actually needs 3.12. The 3.12 cap was a support statement, not a functional dependency. Hard-failing at import is too aggressive — users with known-good older-Python environments should be able to opt in per-workspace.

## API Changes

- `autoconf/__init__.py`: new private `_python_version_check_bypassed()` helper that does a minimal `yaml.safe_load(Path.cwd() / "config" / "general.yaml")` and returns `True` iff the `version.python_version_check` key is explicitly `False`. Any read/parse failure (missing file, missing yaml module, missing key, bad YAML) falls through to the raise, so the default fails safely.
- The raise now includes the YAML snippet the user needs to add to bypass.

## Paired PR

- `autolens_workspace`: [feature/soften-python-version-check](https://github.com/PyAutoLabs/autolens_workspace/pull/new/feature/soften-python-version-check) adds the new `version:` block to the shipped `config/general.yaml` with `python_version_check: True` as the default.

## Test plan

- [x] `pytest test_autoconf/` on Python 3.12 (87 passed)
- [x] On PyAutoGPU (Python 3.10): `python -c "import autoconf"` with the default `True` setting → raises with the new multi-line message referencing 3.9/3.10/3.11 and the bypass snippet
- [x] On PyAutoGPU (Python 3.10): flip to `python_version_check: False` → import succeeds, `scripts/imaging/modeling.py` (with `PYAUTO_TEST_MODE=2`) runs past the version gate into model-fitting
- [x] `cd /tmp && python -c "import autoconf"` on 3.10 (no workspace config) → still raises, message unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)