### PR TITLE
docs: update stale Python >= 3.9 claim to Python >= 3.12

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **PyAutoConf** is the configuration management library for the PyAuto ecosystem. It handles object serialization/deserialization via YAML, JSON-based priors and configuration generation, and provides utility tools for scientific Python applications.
 
 - Package name: `autoconf`
-- Requires Python >= 3.9
+- Requires Python >= 3.12
 
 ## Repository Structure
 


### PR DESCRIPTION
## Summary
Updates the stale "Python >= 3.9" line in this repo's top-level docs to
"Python >= 3.12", matching the actual `requires-python>=3.12` pin in the
relevant `pyproject.toml`.

Follows on from PyAutoFit#1236 / PyAutoGalaxy#378 / PyAutoLens#481, which
added install-docs notes about the Python 3.9/3.10/3.11 drop. With this
PR the public-facing version claim is consistent everywhere.

## API Changes
None — docs-only.

## Test Plan
- [ ] Visual confirmation that the line now reads "Python >= 3.12" (or
      "Python 3.12 and later" in the euclid README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)