### PR TITLE
docs: convert remaining prose .rst to MyST .md (pass 2)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 # MANIFEST.in
 exclude .gitignore
 include LICENSE
-include README.rst
+include README.md
 prune .git
 prune build
 prune dist

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# PyAutoConf

--- a/README.rst
+++ b/README.rst
@@ -1,1 +1,0 @@
-# PyAutoConf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "autoconf"
 dynamic = ["version"]
 description = "PyAuto Configration"
-readme = { file = "README.rst", content-type = "text/x-rst" }
+readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "MIT" }
 requires-python = ">=3.9"
 authors = [


### PR DESCRIPTION
## Summary
Continues the rst→md migration started in PyAutoFit#1245. Converts the project README from RST to Markdown.

- `README.rst` → `README.md`
- `pyproject.toml`: `readme` content-type → `text/markdown`
- `MANIFEST.in`: ships `README.md` in the sdist

## Test plan
- [ ] CI green (unit tests + url_check)
- [ ] PyPI long_description renders cleanly under `text/markdown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)