### PR TITLE
refactor: replace os.path with pathlib

### DIFF
--- a/autoconf/directory_config.py
+++ b/autoconf/directory_config.py
@@ -174,7 +174,7 @@ class RecursiveConfig(AbstractConfig):
                     [
                         path != "priors",
                         len(path.split(".")[0]) != 0,
-                        os.path.isdir(f"{self.path}/{path}")
+                        (self.path / path).is_dir()
                         or path.endswith(".ini")
                         or path.endswith(".yaml")
                         or path.endswith(".yml"),
@@ -204,7 +204,7 @@ class RecursiveConfig(AbstractConfig):
         yaml_name = f"{item}.yaml"
         if yaml_name in listing:
             return YAMLConfig(self.path / yaml_name)
-        if item in listing and os.path.isdir(self.path / item):
+        if item in listing and (self.path / item).is_dir():
             return RecursiveConfig(self.path / item)
         raise KeyError(f"No configuration found for {item} at path {self.path}")
 

--- a/autoconf/json_prior/generate.py
+++ b/autoconf/json_prior/generate.py
@@ -2,7 +2,6 @@ import inspect
 import json
 import logging
 import os
-from os import path
 from importlib import util
 from pathlib import Path
 
@@ -51,9 +50,9 @@ def generate(directory: str):
     directory
         The directory for which prior are generated
     """
-    cwd = Path(os.getcwd())
+    cwd = Path.cwd()
     try:
-        os.mkdir(path.join(cwd, "priors"))
+        (cwd / "priors").mkdir()
     except FileExistsError:
         pass
     for directory, _, files in os.walk(directory):
@@ -64,7 +63,7 @@ def generate(directory: str):
                 spec = for_file(full_path)
                 config_path = cwd / "priors" / file.replace(".py", ".json")
                 if len(spec) > 0:
-                    if os.path.exists(config_path):
+                    if config_path.exists():
                         logger.info(f"{config_path} already exists")
                         continue
                     with open(config_path, "w+") as f:

--- a/autoconf/setup_colab.py
+++ b/autoconf/setup_colab.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 os.environ['XLA_FLAGS'] = "--xla_disable_hlo_passes=constant_folding"
 
 logger = logging.getLogger(__name__)
@@ -103,8 +104,8 @@ def _colab_setup(
     os.chdir(workspace_dir)
 
     conf.instance.push(
-        new_path=os.path.join(workspace_dir, "config"),
-        output_path=os.path.join(workspace_dir, "output"),
+        new_path=Path(workspace_dir) / "config",
+        output_path=Path(workspace_dir) / "output",
     )
 
     print(

--- a/test_autoconf/test_config.py
+++ b/test_autoconf/test_config.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from os import path
+from pathlib import Path
 
 import pytest
 
@@ -9,7 +9,7 @@ from autoconf.directory_config import NamedConfig
 from autoconf.mock.mock_real import EllProfile, Gaussian
 from autoconf.exc import ConfigException
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 class MockClass:

--- a/test_autoconf/test_fitsable.py
+++ b/test_autoconf/test_fitsable.py
@@ -3,20 +3,19 @@ import pytest
 from astropy.io import fits
 import numpy as np
 import os
-from os import path
+from pathlib import Path
 
 from autoconf import conf
 from autoconf import fitsable
 
-test_path = "{}".format(path.dirname(path.realpath(__file__)))
+test_path = Path(__file__).resolve().parent
 
-test_data_path = os.path.join(
-    "{}".format(os.path.dirname(os.path.realpath(__file__))), "files"
-)
+test_data_path = Path(__file__).resolve().parent / "files"
 
 
 def create_fits(fits_path, array):
-    if path.exists(fits_path):
+    fits_path = Path(fits_path)
+    if fits_path.exists():
         os.remove(fits_path)
 
     hdu_list = fits.HDUList()
@@ -29,22 +28,22 @@ def create_fits(fits_path, array):
 
 def test__ndarray_via_fits_from():
     arr = fitsable.ndarray_via_fits_from(
-        file_path=os.path.join(test_data_path, "3x3_ones.fits"), hdu=0
+        file_path=test_data_path / "3x3_ones.fits", hdu=0
     )
 
     assert (arr == np.ones((3, 3))).all()
 
     arr = fitsable.ndarray_via_fits_from(
-        file_path=os.path.join(test_data_path, "4x3_ones.fits"), hdu=0
+        file_path=test_data_path / "4x3_ones.fits", hdu=0
     )
 
     assert (arr == np.ones((4, 3))).all()
 
 
 def test__output_to_fits():
-    file_path = os.path.join(test_data_path, "array_out.fits")
+    file_path = test_data_path / "array_out.fits"
 
-    if os.path.exists(file_path):
+    if file_path.exists():
         os.remove(file_path)
 
     arr = np.array([[10.0, 30.0, 40.0], [92.0, 19.0, 20.0]])
@@ -57,9 +56,9 @@ def test__output_to_fits():
 
 
 def test__output_to_fits__header_dict():
-    file_path = os.path.join(test_data_path, "array_out.fits")
+    file_path = test_data_path / "array_out.fits"
 
-    if os.path.exists(file_path):
+    if file_path.exists():
         os.remove(file_path)
 
     arr = np.array([[10.0, 30.0, 40.0], [92.0, 19.0, 20.0]])
@@ -73,7 +72,7 @@ def test__output_to_fits__header_dict():
 
 def test__header_obj_from():
     header_obj = fitsable.header_obj_from(
-        file_path=os.path.join(test_data_path, "3x3_ones.fits"), hdu=0
+        file_path=test_data_path / "3x3_ones.fits", hdu=0
     )
 
     assert isinstance(header_obj, fits.header.Header)


### PR DESCRIPTION
## Summary

Mechanical refactor replacing all `os.path.*` and bare `path.*` (from `from os import path`) usages with `pathlib.Path`. Part of cross-repo issue PyAutoLabs/PyAutoFit#1257 — the codebase already used `pathlib` extensively in newer code; this sweeps up the remaining legacy usages for consistency.

## API Changes

None — internal changes only. All public function signatures unchanged. Implementation switches from string-style joins to Path objects, but returned values, accepted argument types, and external behaviour are unchanged. Some test fixtures (`PlotPatch`) now stringify recorded paths to keep assertions stable.

See full details below.

## Test Plan

- [ ] `python -m pytest test_<repo>/` passes (CI)
- [ ] Verified locally as part of cross-repo sweep (3,188 tests across PyAutoConf/PyAutoFit/PyAutoArray/PyAutoGalaxy/PyAutoLens)
- [ ] No public API changed — workspace scripts should be unaffected (separate workspace PR follows for tutorial/example consistency)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None — no public symbols removed

### Added
- None — no new public symbols

### Renamed
- None

### Changed Signature
- None

### Changed Behaviour
- None observable. Internal helpers now build paths with `Path / "..."` instead of `os.path.join`, but consumers that accept `str | os.PathLike` see the same effective path.

### Migration
- No user migration needed.

</details>

Refs PyAutoLabs/PyAutoFit#1257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)