### PR TITLE
Bump JAX floor to 0.7.0 to match nufftax 0.4.0 runtime needs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ local_scheme = "no-local-version"
 
 [project.optional-dependencies]
 jax = [
-    "jax>=0.4.35,<0.10.0; python_version >= '3.11'",
-    "jaxlib>=0.4.35,<0.10.0; python_version >= '3.11'",
+    "jax>=0.7.0,<0.11.0; python_version >= '3.11'",
+    "jaxlib>=0.7.0,<0.11.0; python_version >= '3.11'",
     "jaxnnls==1.0.1; python_version >= '3.11'"
 ]
 optional = [


### PR DESCRIPTION
## Summary

- Raises the JAX pin in the `[jax]` extra from `jax>=0.4.35,<0.10.0` to `jax>=0.7.0,<0.11.0` (matching `jaxlib`).
- Fixes a user-reported `AttributeError: module 'jax.experimental.pallas.triton' has no attribute 'CompilerParams'` that fired when pip happened to resolve to JAX 0.4.x alongside nufftax 0.4.0.
- Foundation PR — PyAutoArray and PyAutoGalaxy companion PRs depend on this landing first.

## Why

nufftax 0.4.0 calls `jax.experimental.pallas.triton.CompilerParams`, which was renamed from `TritonCompilerParams` in JAX 0.7.0. nufftax's own metadata declares `jax>=0.4.0` (too loose), so the previous floor here let pip create installs that crashed at runtime on `subplot_interferometer_dirty_images`.

Ceiling moves to `<0.11.0` so we still permit the just-released 0.10.x line. Audited PyAuto source for `jax.pmap` and `PartitionSpec` tuple equality (the two breaking changes in JAX 0.10.0) — neither is used.

## Test plan

- [x] Local install of `jaxnnls==1.0.1 + jax==0.7.0` succeeds
- [x] Local install of `jaxnnls==1.0.1 + jax==0.10.1` succeeds
- [x] PyAutoConf full unit tests pass on JAX 0.9.2 with new pins (95 passed)
- [ ] CI green on Python 3.12 / 3.13
- [ ] TestPyPI rehearsal: `verify_install --testpypi` passes once dispatched (companion PyAutoBuild PR)

## Companion PRs

Cross-references will be added once those PRs are open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)