### PR TITLE
feat: add skip_latents() to test_mode helpers

### DIFF
--- a/autoconf/test_mode.py
+++ b/autoconf/test_mode.py
@@ -48,3 +48,16 @@ def skip_checks():
     inversion position exceptions, sample weight thresholds.
     """
     return os.environ.get("PYAUTO_SKIP_CHECKS", "0") == "1"
+
+
+def skip_latents():
+    """
+    Return True if latent variable computation should be skipped.
+
+    Auto-enabled when any ``PYAUTO_TEST_MODE`` level is active (test-mode
+    fits mock the underlying samples, so latent values are not meaningful)
+    and can also be triggered independently via ``PYAUTO_SKIP_LATENTS=1``
+    for real-mode fits where the user wants to bypass the post-fit
+    ``compute_latent_samples`` pass.
+    """
+    return is_test_mode() or os.environ.get("PYAUTO_SKIP_LATENTS", "0") == "1"


### PR DESCRIPTION
## Summary

Adds a `skip_latents()` helper to `autoconf/test_mode.py`, mirroring the existing `skip_visualization()` / `skip_checks()` pattern. Returns `True` when any `PYAUTO_TEST_MODE` level is active (test-mode fits mock the underlying samples, so latent values are not meaningful) and can also be triggered independently via `PYAUTO_SKIP_LATENTS=1` for real-mode fits where the user wants to bypass the post-fit `compute_latent_samples` pass.

Consumed by PyAutoFit's `SearchUpdater._compute_latent_samples` short-circuit (rhayes777/PyAutoFit#1294). Tracking issue: rhayes777/PyAutoFit#1294.

## API Changes

Added `autoconf.test_mode.skip_latents()` returning a `bool`. No other surface affected — purely additive.

See full details below.

## Test Plan

- [x] `python -m pytest test_autoconf/` passes (95/95).
- [x] Downstream PyAutoFit consumer test (`test_autofit/non_linear/search/test_updater.py`) imports and uses it cleanly.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added

- `autoconf.test_mode.skip_latents() -> bool` — returns `is_test_mode() or os.environ.get("PYAUTO_SKIP_LATENTS", "0") == "1"`. Composes the existing `is_test_mode()` trigger with a new `PYAUTO_SKIP_LATENTS` env-var override.

### Removed / Renamed / Changed

None.

### Migration

None. Existing callers of `is_test_mode()`, `skip_visualization()`, `skip_checks()`, `skip_fit_output()` are unaffected.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)