### PR TITLE
feat: workspace_dir override in setup_colab.setup (CI Colab simulation)

### DIFF
--- a/autoconf/setup_colab.py
+++ b/autoconf/setup_colab.py
@@ -266,7 +266,11 @@ def _colab_setup(
     )
 
 
-def setup(project: str, raise_error_if_not_gpu: bool = False) -> None:
+def setup(
+    project: str,
+    raise_error_if_not_gpu: bool = False,
+    workspace_dir: str = None,
+) -> None:
     """
     Set up Google Colab for a PyAuto notebook repository.
 
@@ -278,6 +282,11 @@ def setup(project: str, raise_error_if_not_gpu: bool = False) -> None:
     raise_error_if_not_gpu
         If True, raise instead of continuing when Colab has no GPU / TPU
         runtime enabled.
+    workspace_dir
+        Where to clone the workspace. Defaults to the project's Colab
+        directory (``/content/<workspace>``); overridden by CI environments
+        that simulate the Colab bootstrap (e.g. PyAutoHeart's verify_install
+        check F), where ``/content`` is not writable.
     """
     try:
         spec = _PROJECTS[project]
@@ -289,7 +298,7 @@ def setup(project: str, raise_error_if_not_gpu: bool = False) -> None:
     _colab_setup(
         project_name=spec["project_name"],
         workspace_repo=spec["workspace_repo"],
-        workspace_dir=spec["workspace_dir"],
+        workspace_dir=workspace_dir or spec["workspace_dir"],
         packages=spec["packages"],
         top_package=spec["top_package"],
         raise_error_if_not_gpu=raise_error_if_not_gpu,

--- a/test_autoconf/test_setup_colab.py
+++ b/test_autoconf/test_setup_colab.py
@@ -159,3 +159,18 @@ class TestCloneWorkspace:
                 setup_colab._clone_workspace("repo_url", target, "autolens")
         run.assert_called_once()
         assert "--branch" not in run.call_args[0][0]
+
+
+class TestWorkspaceDirOverride:
+    def test_override_threads_to_colab_setup(self):
+        with mock.patch.object(setup_colab, "_colab_setup") as colab_setup:
+            setup_colab.setup("autolens", workspace_dir="/tmp/sim_ws")
+        assert colab_setup.call_args[1]["workspace_dir"] == "/tmp/sim_ws"
+
+    def test_default_is_the_registry_colab_dir(self):
+        with mock.patch.object(setup_colab, "_colab_setup") as colab_setup:
+            setup_colab.setup("autolens")
+        assert (
+            colab_setup.call_args[1]["workspace_dir"]
+            == "/content/autolens_workspace"
+        )


### PR DESCRIPTION
## Summary

Adds a `workspace_dir` override to `setup_colab.setup` so CI can simulate the Colab bootstrap: the `_PROJECTS` registry hardcodes Colab's `/content/<workspace>` directories, which CI runners cannot write. PyAutoHeart's new `verify_install` check F (PyAutoLabs/PyAutoHeart#46, same branch name) passes its throwaway clone target through this parameter. Default behavior is unchanged — on real Colab the registry directory is used exactly as before.

Part of PyAutoLabs/PyAutoHeart#45.

## API Changes

Added an optional keyword-only-in-practice parameter: `setup_colab.setup(project, raise_error_if_not_gpu=False, workspace_dir=None)`. Backward compatible; no existing call site changes.
See full details below.

## Test Plan
- [x] `python -m pytest test_autoconf/` — 134 passed (2 new: override threads to `_colab_setup`; default remains the registry Colab dir)
- [x] Exercised for real by the check-F driver: clone landed detached at the `2026.7.6.649` tag inside the override directory, config pushed, notebook cell ran

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `setup_colab.setup(..., workspace_dir: str = None)` — clone-target override for CI Colab simulation; `None` keeps the registry's `/content/<workspace>` default.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
