### PR TITLE
docs: human-led natural-language tone sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ CSV serialization of arbitrary objects, and FITS I/O.
 autoconf: it supplies their packaged default config, the object-serialization
 used to persist models and results, and shared utilities (`test_mode`,
 `jax_wrapper`). Centralising these here keeps a single, consistent config and
-I/O layer beneath every library.
+I/O layer beneath every library. Within the human-led
+[PyAutoScientist organism](https://pyautoscientist.readthedocs.io) it is the
+Nerves — the layer connecting the workspace's conventions to every library.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CSV serialization of arbitrary objects, and FITS I/O.
 autoconf: it supplies their packaged default config, the object-serialization
 used to persist models and results, and shared utilities (`test_mode`,
 `jax_wrapper`). Centralising these here keeps a single, consistent config and
-I/O layer beneath every library. Within the human-led
+I/O layer beneath every library. Within the
 [PyAutoScientist organism](https://pyautoscientist.readthedocs.io) it is the
 Nerves — the layer connecting the workspace's conventions to every library.
 


### PR DESCRIPTION
Part of the human-led tone sweep — PyAutoLabs/PyAutoBrain#81. Rewords the organism framing to the voice settled on the [org front page](https://github.com/PyAutoLabs): you lead in plain English, agents plan/build/test/release, you make every judgment call. Tone only — no boundary or contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)