### PR TITLE
docs: prominent PyAutoScientist docs link at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PyAutoConf
 
+📖 **Full documentation → <https://pyautoscientist.readthedocs.io>** — the whole PyAutoScientist organism, including how to fork and run your own.
+
 **PyAutoConf** (package `autoconf`) is the configuration, serialization, and
 I/O foundation of the [PyAuto](https://github.com/PyAutoLabs) ecosystem. It
 provides a layered configuration system with workspace overrides, dict / JSON /


### PR DESCRIPTION
Surfaces the PyAutoScientist docs link (<https://pyautoscientist.readthedocs.io>) directly under the README title — it was previously buried lower down and easy to miss when not arriving via the PyAutoLabs front door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)