### PR TITLE
perf: cache JSONPriorConfig lookups (model deserialization -44%)

### DIFF
--- a/autoconf/json_prior/config.py
+++ b/autoconf/json_prior/config.py
@@ -55,6 +55,13 @@ def path_for_class(cls) -> List[str]:
     return f"{cls.__module__}.{cls.__name__}".split(".")
 
 
+# Sentinels for the per-instance lookup cache: a query can legitimately resolve to
+# None, and the class-family probe in for_class_and_suffix_path relies on repeated
+# expected misses, so both found-None and not-found must be cacheable.
+_UNCACHED = object()
+_NOT_FOUND = object()
+
+
 class JSONPriorConfig:
     def __init__(self, config_dict: dict, directory=None):
         """
@@ -79,6 +86,8 @@ class JSONPriorConfig:
         self.obj = config_dict
         self.directory = directory
         self._path_value_map = None
+        self._path_value_tuples = None
+        self._lookup_cache = {}
 
     @property
     def paths(self):
@@ -109,12 +118,18 @@ class JSONPriorConfig:
         """
         Tuple pairs matching every possible path to the configuration it points to.
         These are ordered by key length with the longest key first.
+
+        Cached on the instance — this is consulted for every prior of every model
+        construction, and re-sorting the flattened configuration per lookup
+        dominated model deserialization.
         """
-        return sorted(
-            list(self.path_value_map.items()),
-            key=lambda item: len(item[0]),
-            reverse=True,
-        )
+        if self._path_value_tuples is None:
+            self._path_value_tuples = sorted(
+                list(self.path_value_map.items()),
+                key=lambda item: len(item[0]),
+                reverse=True,
+            )
+        return self._path_value_tuples
 
     @classmethod
     def from_directory(cls, directory: str) -> "JSONPriorConfig":
@@ -209,9 +224,20 @@ class JSONPriorConfig:
             If no configuration is found.
         """
         key = ".".join(config_path)
+        cached = self._lookup_cache.get(key, _UNCACHED)
+        if cached is _NOT_FOUND:
+            raise KeyError(
+                f"No configuration was found for the path {config_path}"
+                + ("" if self.directory is None else f" ({self.directory})")
+            )
+        if cached is not _UNCACHED:
+            return cached
+
         for path, value in self.path_value_tuples:
             if key.endswith(path):
+                self._lookup_cache[key] = value
                 return value
+        self._lookup_cache[key] = _NOT_FOUND
         raise KeyError(
             f"No configuration was found for the path {config_path}"
             + ("" if self.directory is None else f" ({self.directory})")

--- a/test_autoconf/json_prior/test_config.py
+++ b/test_autoconf/json_prior/test_config.py
@@ -1,0 +1,19 @@
+
+
+def test_lookup_cache_repeats_and_misses():
+    """
+    Lookups are memoised per instance — including misses, which the class-family
+    probe in for_class_and_suffix_path performs repeatedly by design.
+    """
+    import pytest
+    from autoconf.json_prior.config import JSONPriorConfig
+
+    config = JSONPriorConfig({"module.Class": {"value": 1}})
+
+    assert config(["pkg", "module", "Class"]) == {"value": 1}
+    assert config(["pkg", "module", "Class"]) == {"value": 1}
+
+    with pytest.raises(KeyError):
+        config(["pkg", "module", "Missing"])
+    with pytest.raises(KeyError):
+        config(["pkg", "module", "Missing"])


### PR DESCRIPTION
## Summary

The aggregator arc's recorded "deeper follow-up" (#129): cProfile showed **77% of per-result summary/model deserialization is `Model.__init__` building default priors from prior config**, and most of that was two defects in `JSONPriorConfig`:

1. `path_value_tuples` **re-sorted the entire flattened config dict on every lookup** — the flattened map was cached, the sort was not.
2. `__call__` then linear-scanned the tuples, with identical queries repeating for every prior of every model construction (thousands of times when aggregating a catalogue).

Fix: cache the sorted tuples and memoize lookups per instance — including misses, which the class-family probe in `for_class_and_suffix_path` performs repeatedly by design (a `_NOT_FOUND` sentinel; found-`None` is also representable). Invalidation is structural: config pushes construct fresh `JSONPriorConfig` instances, and returned sub-dicts were already aliased across repeated calls, so no new sharing is introduced.

Measured (100 mock results, like-for-like load, best of 3):

- `values("model")`: 8.15 → 4.60 ms/result (**−44%**)
- `values("samples_summary")`: 8.73 → 6.58 ms/result (−25%; includes sample-json costs the cache doesn't touch)

This benefits every `Model`/`Collection` construction (search startup included), not just the aggregator.

## API Changes

None — internal caching only; lookup results and exception behaviour are unchanged.

## Test Plan

- [x] `pytest test_autoconf` — 147 passed (+ new cache regression test: repeated hits and repeated misses)
- [x] Full downstream `pytest test_autofit/` — 1495 passed, 1 skipped
- [x] Before/after measurement above via the aggregator profiling harness

Generated by the PyAutoLabs agent workflow.
