### PR TITLE
docs: mark PyAutoConf as the Nerves organ + generated organism map (#84)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,35 @@
 Canonical, agent-agnostic instructions for this repo. `CLAUDE.md` imports this
 file; any tool that does not process `@`-imports should read this directly.
 
+**This repo is the Nerves organ of the PyAuto organism** — the base
+configuration/serialization layer (`autoconf`) that every scientific library
+imports. It is a full organ (promoted to the seventh organ 2026-07); the
+organism map below is generated from `PyAutoMind/repos.yaml`.
+
+## The organism map
+
+<!-- repos_sync:map:begin -->
+**You are one organ of the PyAuto organism** — an agentic ecosystem for
+human-led, natural-language software development. The organs below are
+peer repositories; this repo is one of them, not a part of another.
+Canonical boundaries live in `PyAutoBrain/ORGANISM.md`; the full body map
+(every repo, not just organs) is `PyAutoMind/repos.yaml`.
+
+| Organ | Repo | Role |
+|-------|------|------|
+| **Mind** | PyAutoMind | Intent, goals, priorities, workflow state; every task starts as a markdown prompt here. |
+| **Brain** | PyAutoBrain | Reasoning/orchestration layer; how work is decomposed and routed; the specialist agents. |
+| **Hands** | PyAutoBuild | Packaging, tagging, notebook generation, PyPI release execution. |
+| **Heart** | PyAutoHeart | Health/readiness — the authoritative "is it safe to release?" verdict. |
+| **Memory** | PyAutoMemory | Long-term scientific/software/project knowledge (see science pointer below). |
+| **Gut** | PyAutoGut | Owns the lifecycle of condemned self-material (stale branches, stashes, dead code/tests): holds it as durable, recoverable git refs through a transit window and voids it on a sweep. The storage mirror of Memory (retention vs release). |
+| **Nerves** | PyAutoConf | The Nerves — the configuration/serialization layer connecting workspace conventions to libraries (layered config, version handshake, test_mode), delivered as the `autoconf` package. |
+
+Call chain (always this order): **Brain → Heart (gate) → Build (execute)**. Brain agents are **conductors** (front-door; a human drives them; they decide *and* act) or **faculties** (read-only opinions the conductors consult; they judge and stop). New capability grows as a faculty, not a new organ, unless it owns state or effects no existing organ can.
+
+Generated from `PyAutoMind/repos.yaml` + `PyAutoBrain/ORGANISM.md`; edit there, then run `python3 PyAutoMind/scripts/repos_sync.py --write`.
+<!-- repos_sync:map:end -->
+
 ## What this repo is
 
 **PyAutoConf** (package `autoconf`) is the configuration, serialization, and


### PR DESCRIPTION
Part of the organism docs sweep (#84, WS1).

Reconciles the code's strict-6 internal map with the public 7-organ model by promoting Nerves (PyAutoConf) to a full organ:
- Added the "**this repo is the Nerves organ**" line to the intro.
- Added the `repos_sync:map` markers; the organism-map block (7 organs) is generated from `PyAutoMind/repos.yaml`.

The repo identity name stays `PyAutoConf` — the `PyAutoConf → PyAutoNerves` rename is a deliberate mechanical follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERDgNVKpQohYXVcJwAHzmw)_