### PR TITLE
test: re-anchor the version-handshake test fixtures

### DIFF
--- a/test_autonerves/test_setup_colab.py
+++ b/test_autonerves/test_setup_colab.py
@@ -128,7 +128,7 @@ class TestCloneWorkspace:
 
     def test_clones_release_tag_when_available(self, tmp_path):
         target = str(tmp_path / "ws")
-        with mock.patch.object(setup_colab, "_installed_version", return_value="2026.7.6.649"):
+        with mock.patch.object(setup_colab, "_installed_version", return_value="2026.7.22.1"):
             with mock.patch.object(
                 subprocess, "run", return_value=mock.Mock(returncode=0)
             ) as run:
@@ -136,7 +136,7 @@ class TestCloneWorkspace:
         run.assert_called_once()
         args = run.call_args[0][0]
         assert args[:4] == ["git", "clone", "--depth", "1"]
-        assert ["--branch", "2026.7.6.649"] == args[4:6]
+        assert ["--branch", "2026.7.22.1"] == args[4:6]
 
     def test_falls_back_to_default_branch_when_tag_missing(self, tmp_path):
         target = str(tmp_path / "ws")

--- a/test_autonerves/test_workspace.py
+++ b/test_autonerves/test_workspace.py
@@ -13,16 +13,16 @@ def _write_general_yaml(tmp_path, body):
 
 
 def test_match_via_version_txt(tmp_path):
-    (tmp_path / "version.txt").write_text("2026.4.13.6\n")
-    check_version("2026.4.13.6", workspace_root=tmp_path)
+    (tmp_path / "version.txt").write_text("2026.7.22.1\n")
+    check_version("2026.7.22.1", workspace_root=tmp_path)
 
 
 def test_mismatch_via_version_txt_raises(tmp_path):
-    (tmp_path / "version.txt").write_text("2026.4.13.6\n")
+    (tmp_path / "version.txt").write_text("2026.7.22.1\n")
     with pytest.raises(WorkspaceVersionMismatchError) as info:
         check_version("2025.1.1.1", workspace_root=tmp_path)
     msg = str(info.value)
-    assert "2026.4.13.6" in msg
+    assert "2026.7.22.1" in msg
     assert "2025.1.1.1" in msg
     assert "workspace_version_check: False" in msg
     assert "main" in msg
@@ -30,24 +30,24 @@ def test_mismatch_via_version_txt_raises(tmp_path):
 
 def test_missing_sources_warns(tmp_path):
     with pytest.warns(UserWarning, match="workspace_version_check: False"):
-        check_version("2026.4.13.6", workspace_root=tmp_path)
+        check_version("2026.7.22.1", workspace_root=tmp_path)
 
 
 def test_env_override_skips_mismatch(tmp_path, monkeypatch):
     monkeypatch.setenv("PYAUTO_SKIP_WORKSPACE_VERSION_CHECK", "1")
     (tmp_path / "version.txt").write_text("2025.1.1.1\n")
-    check_version("2026.4.13.6", workspace_root=tmp_path)
+    check_version("2026.7.22.1", workspace_root=tmp_path)
 
 
 def test_env_override_skips_missing_file(tmp_path, monkeypatch):
     monkeypatch.setenv("PYAUTO_SKIP_WORKSPACE_VERSION_CHECK", "1")
-    check_version("2026.4.13.6", workspace_root=tmp_path)
+    check_version("2026.7.22.1", workspace_root=tmp_path)
 
 
 def test_default_root_is_cwd(tmp_path, monkeypatch):
-    (tmp_path / "version.txt").write_text("2026.4.13.6\n")
+    (tmp_path / "version.txt").write_text("2026.7.22.1\n")
     monkeypatch.chdir(tmp_path)
-    check_version("2026.4.13.6")
+    check_version("2026.7.22.1")
 
 
 def test_match_via_general_yaml(tmp_path):
@@ -55,11 +55,11 @@ def test_match_via_general_yaml(tmp_path):
         tmp_path,
         """
         version:
-          workspace_version: 2026.4.13.6
+          workspace_version: 2026.7.22.1
           workspace_version_check: True
         """,
     )
-    check_version("2026.4.13.6", workspace_root=tmp_path)
+    check_version("2026.7.22.1", workspace_root=tmp_path)
 
 
 def test_mismatch_via_general_yaml_raises(tmp_path):
@@ -67,7 +67,7 @@ def test_mismatch_via_general_yaml_raises(tmp_path):
         tmp_path,
         """
         version:
-          workspace_version: 2026.4.13.6
+          workspace_version: 2026.7.22.1
           workspace_version_check: True
         """,
     )
@@ -80,7 +80,7 @@ def test_yaml_bypass_skips_mismatch(tmp_path):
         tmp_path,
         """
         version:
-          workspace_version: 2026.4.13.6
+          workspace_version: 2026.7.22.1
           workspace_version_check: False
         """,
     )
@@ -95,7 +95,7 @@ def test_yaml_bypass_skips_missing_version_key(tmp_path):
           workspace_version_check: False
         """,
     )
-    check_version("2026.4.13.6", workspace_root=tmp_path)
+    check_version("2026.7.22.1", workspace_root=tmp_path)
 
 
 def test_yaml_overrides_version_txt_when_both_present(tmp_path):
@@ -103,11 +103,11 @@ def test_yaml_overrides_version_txt_when_both_present(tmp_path):
         tmp_path,
         """
         version:
-          workspace_version: 2026.4.13.6
+          workspace_version: 2026.7.22.1
         """,
     )
     (tmp_path / "version.txt").write_text("2025.1.1.1\n")
-    check_version("2026.4.13.6", workspace_root=tmp_path)
+    check_version("2026.7.22.1", workspace_root=tmp_path)
 
 
 def test_version_txt_used_when_yaml_lacks_workspace_version(tmp_path):
@@ -118,8 +118,8 @@ def test_version_txt_used_when_yaml_lacks_workspace_version(tmp_path):
           python_version_check: True
         """,
     )
-    (tmp_path / "version.txt").write_text("2026.4.13.6\n")
-    check_version("2026.4.13.6", workspace_root=tmp_path)
+    (tmp_path / "version.txt").write_text("2026.7.22.1\n")
+    check_version("2026.7.22.1", workspace_root=tmp_path)
 
 
 def test_yaml_without_version_key_falls_through_to_warning(tmp_path):
@@ -131,28 +131,28 @@ def test_yaml_without_version_key_falls_through_to_warning(tmp_path):
         """,
     )
     with pytest.warns(UserWarning):
-        check_version("2026.4.13.6", workspace_root=tmp_path)
+        check_version("2026.7.22.1", workspace_root=tmp_path)
 
 
 def test_unparseable_yaml_falls_back_to_version_txt(tmp_path):
     config_dir = tmp_path / "config"
     config_dir.mkdir()
     (config_dir / "general.yaml").write_text("::: not valid yaml :::")
-    (tmp_path / "version.txt").write_text("2026.4.13.6\n")
-    check_version("2026.4.13.6", workspace_root=tmp_path)
+    (tmp_path / "version.txt").write_text("2026.7.22.1\n")
+    check_version("2026.7.22.1", workspace_root=tmp_path)
 
 
 def test_newer_library_within_window_passes_silently(tmp_path):
-    (tmp_path / "version.txt").write_text("2026.4.13.6\n")
+    (tmp_path / "version.txt").write_text("2026.7.22.1\n")
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        check_version("2026.4.20.1", workspace_root=tmp_path)
+        check_version("2026.7.29.1", workspace_root=tmp_path)
 
 
 def test_newer_library_beyond_window_warns_stale(tmp_path):
-    (tmp_path / "version.txt").write_text("2026.4.13.6\n")
+    (tmp_path / "version.txt").write_text("2026.7.22.1\n")
     with pytest.warns(UserWarning, match="git pull"):
-        check_version("2026.6.1.1", workspace_root=tmp_path)
+        check_version("2026.9.9.1", workspace_root=tmp_path)
 
 
 def test_minimum_library_version_key_is_the_floor(tmp_path):
@@ -160,13 +160,13 @@ def test_minimum_library_version_key_is_the_floor(tmp_path):
         tmp_path,
         """
         version:
-          minimum_library_version: 2026.4.13.6
+          minimum_library_version: 2026.7.22.1
           workspace_version: 2027.1.1.1
         """,
     )
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        check_version("2026.4.20.1", workspace_root=tmp_path)
+        check_version("2026.7.29.1", workspace_root=tmp_path)
 
 
 def test_below_minimum_library_version_raises_with_upgrade_advice(tmp_path):
@@ -176,7 +176,7 @@ def test_below_minimum_library_version_raises_with_upgrade_advice(tmp_path):
         workspace_root,
         """
         version:
-          minimum_library_version: 2026.4.13.6
+          minimum_library_version: 2026.7.22.1
         """,
     )
     with pytest.raises(WorkspaceVersionMismatchError) as info:
@@ -187,7 +187,7 @@ def test_below_minimum_library_version_raises_with_upgrade_advice(tmp_path):
 
 
 def test_unparseable_library_version_warns_not_raises(tmp_path):
-    (tmp_path / "version.txt").write_text("2026.4.13.6\n")
+    (tmp_path / "version.txt").write_text("2026.7.22.1\n")
     with pytest.warns(UserWarning, match="cannot be compared"):
         check_version("1.0.dev0", workspace_root=tmp_path)
 
@@ -195,4 +195,4 @@ def test_unparseable_library_version_warns_not_raises(tmp_path):
 def test_unparseable_workspace_record_warns_not_raises(tmp_path):
     (tmp_path / "version.txt").write_text("not-a-version\n")
     with pytest.warns(UserWarning, match="cannot be compared"):
-        check_version("2026.4.13.6", workspace_root=tmp_path)
+        check_version("2026.7.22.1", workspace_root=tmp_path)


### PR DESCRIPTION
Re-anchors the `check_version` test fixtures. **Fixtures only — `__version__` is not touched.**

### Why

The fixtures were pinned to April 2026 values, and the colab mock returned `2026.7.6.649` — one of the accidental `run_number` releases that was **yanked from PyPI**. A test fixture should not name an uninstallable version.

### The deltas, not the dates

These are arbitrary sentinels; nothing reads a real release. What matters is the deltas (`_STALENESS_WINDOW_DAYS = 30`):

| Fixture | Old | New | Delta |
|---|---|---|---|
| base workspace version | `2026.4.13.6` | `2026.7.22.1` | anchor |
| within-window library | `2026.4.20.1` | `2026.7.29.1` | **+7d** ≤ 30 → silent |
| beyond-window library | `2026.6.1.1` | `2026.9.9.1` | **+49d** > 30 → warns |
| colab mock version | `2026.7.6.649` | `2026.7.22.1` | off the yanked release |

**Unchanged deliberately:** `2025.1.1.1` (the "much older" mismatch sentinel) and `2027.1.1.1` (far-future sentinel proving `minimum_library_version` is the floor). A blanket find-replace collapses these into the base value and breaks the mismatch/ordering tests — verified, it fails exactly 3 tests.

### Changed since the first revision

This PR originally also bumped `autonerves/__init__.py` to `2026.7.22.1`. **That has been dropped.**

Releases are wheels+tags only (PyAutoBuild#118/#120): `release.yml` `sed`s the version into the build tree and never commits back to any main. Main's `__version__` is therefore *expected* to lag, and `check_version` is a compatibility **floor**, not an exact pin. Hand-bumping main re-establishes exactly the stamp-commit-back pattern #120 removed. Left at `2026.7.9.1`.

`151 passed`.