### PR TITLE
feat: Python 3.14 supported — classifier + banner derived from supported set

### DIFF
--- a/autonerves/__init__.py
+++ b/autonerves/__init__.py
@@ -31,7 +31,7 @@ def _python_version_check_bypassed():
         return False
 
 
-_RECOMMENDED_PYTHON_VERSIONS = {(3, 12), (3, 13)}
+_RECOMMENDED_PYTHON_VERSIONS = {(3, 12), (3, 13), (3, 14)}
 
 
 def _emit_python_version_warning():
@@ -42,12 +42,18 @@ def _emit_python_version_warning():
         return
 
     py = f"{current[0]}.{current[1]}"
+    supported = [
+        f"{major}.{minor}" for major, minor in sorted(_RECOMMENDED_PYTHON_VERSIONS)
+    ]
+    prose = ", ".join(supported[:-1]) + " and " + supported[-1]
+    choice = ", ".join(supported[:-1]) + " or " + supported[-1]
+    slash = "/".join(supported)
     if current < (3, 12):
         lines = [
             f"PyAuto: Python {py} detected -- Python 3.12 or newer is required.",
             "",
             "This Python version is unsupported by current PyAuto releases.",
-            "Install Python 3.12 or 3.13, or pin a pre-migration PyAuto release.",
+            f"Install Python {choice}, or pin a pre-migration PyAuto release.",
         ]
         warning = (
             f"PyAuto: running on unsupported Python {py}; current releases "
@@ -57,13 +63,13 @@ def _emit_python_version_warning():
         lines = [
             f"PyAuto: Python {py} detected -- this Python version is experimental.",
             "",
-            "PyAuto currently tests and supports Python 3.12 and 3.13.",
+            f"PyAuto currently tests and supports Python {prose}.",
             f"Python {py} may encounter known compatibility issues.",
-            "Use Python 3.12 or 3.13 for production work.",
+            f"Use Python {choice} for production work.",
         ]
         warning = (
             f"PyAuto: running on experimental Python {py}; supported versions "
-            "are 3.12/3.13."
+            f"are {slash}."
         )
     lines.extend(
         [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ classifiers = [
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13"
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14"
 ]
 keywords = ["cli"]
 dependencies = [

--- a/test_autonerves/test_python_version.py
+++ b/test_autonerves/test_python_version.py
@@ -20,7 +20,7 @@ def _set_python_version(monkeypatch, major, minor):
     )
 
 
-@pytest.mark.parametrize("minor", [12, 13])
+@pytest.mark.parametrize("minor", [12, 13, 14])
 def test_supported_python_versions_do_not_warn(monkeypatch, capsys, minor):
     _set_python_version(monkeypatch, major=3, minor=minor)
 
@@ -45,15 +45,15 @@ def test_python_below_minimum_is_reported_as_unsupported(monkeypatch, capsys):
 
 
 def test_python_above_supported_range_is_reported_as_experimental(monkeypatch, capsys):
-    _set_python_version(monkeypatch, major=3, minor=14)
+    _set_python_version(monkeypatch, major=3, minor=15)
 
-    with pytest.warns(UserWarning, match=r"experimental Python 3\.14"):
+    with pytest.warns(UserWarning, match=r"experimental Python 3\.15"):
         autonerves._emit_python_version_warning()
 
     message = capsys.readouterr().err
-    assert "Python 3.14 detected -- this Python version is experimental" in message
-    assert "tests and supports Python 3.12 and 3.13" in message
-    assert "Use Python 3.12 or 3.13 for production work" in message
+    assert "Python 3.15 detected -- this Python version is experimental" in message
+    assert "tests and supports Python 3.12, 3.13 and 3.14" in message
+    assert "Use Python 3.12, 3.13 or 3.14 for production work" in message
 
 
 def test_python_version_warning_respects_yaml_bypass(monkeypatch, tmp_path, capsys):
@@ -66,7 +66,7 @@ def test_python_version_warning_respects_yaml_bypass(monkeypatch, tmp_path, caps
     monkeypatch.setattr(
         autonerves,
         "sys",
-        SimpleNamespace(version_info=(3, 14)),
+        SimpleNamespace(version_info=(3, 15)),
     )
 
     with warnings.catch_warnings(record=True) as caught:


### PR DESCRIPTION
## Summary
Python 3.14 promotion follow-up (blocker fixed in PyAutoLabs/PyAutoFit#1439): add `(3, 14)` to `_RECOMMENDED_PYTHON_VERSIONS` so 3.14 no longer warns as experimental, derive the banner's supported-version strings from that constant (next promotion is a one-line change), and add the 3.14 trove classifier. Verified live: importing autonerves on Python 3.14.4 is now silent.

## API Changes
None — the import-time banner no longer flags 3.14 as experimental; the pre-3.12 hard-floor message is unchanged.

## Test Plan
- [x] `test_autonerves` 155 passed (parametrized no-warn now covers 3.14; experimental-branch and bypass tests retargeted to 3.15).

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)